### PR TITLE
./theos: Better shell checking and using proper profile

### DIFF
--- a/theos
+++ b/theos
@@ -45,10 +45,10 @@ if [ "$(uname -s)" == "Darwin" ]; then
 else linuxInit
 fi
 
-if [ $SHELL == "/usr/bin/zsh" ] || [ $SHELL == "/bin/zsh" ]; then 
-  profile="$HOME/.zshrc"
+if [[ $SHELL == *"zsh"* ]]; then 
+  profile="$HOME/.zprofile"
 else
-  profile="$HOME/.bashrc"
+  profile="$HOME/.profile"
 fi
 
 x=$PWD


### PR DESCRIPTION
This commit allows for `zsh` to be elsewhere than `/bin/zsh` or `/usr/bin/zsh`, which is useful for Homebrew users and others.